### PR TITLE
Update value when the message handler of an iframe is ready

### DIFF
--- a/monaco-editor-iframe.js
+++ b/monaco-editor-iframe.js
@@ -275,6 +275,7 @@
             window.addEventListener('resize', resizeHandler);
 
             window.addEventListener('message', handler);
+            parent.postMessage({editorReference: editorReference, event: 'editor-message-handler-ready'}, parent.document.location.href);
 
             function handler(e) {
               var {path, event, args} = e.data;

--- a/monaco-editor.html
+++ b/monaco-editor.html
@@ -599,6 +599,10 @@ class MonacoEditor extends Polymer.Element {
       if (data.action === 'editor-focused') {
         this._syncSchema();
       }
+
+      if (data.event === 'editor-message-handler-ready') {
+          this._valueChanged(this.value);
+      };
     });
 
     var iframe = new PolymerVis.monaco.MonacoIFrame(this.shadowRoot);


### PR DESCRIPTION
It is possible that the editor is created as iframe and a dynamic value is set before the message handler of the iframe is ready. To avoid this, I send a message when the iframe's handler is set up and the main object will send a value update.