### PR TITLE
Delay messages to the proxy before the handler was activated

### DIFF
--- a/monaco-editor-iframe.js
+++ b/monaco-editor-iframe.js
@@ -5,6 +5,8 @@
     constructor(iframe, editorReference) {
       this._iframe_ = iframe;
       this._editorReference_ = editorReference;
+      this._messageFlowActive_ = false;
+      this._delayedMessages_ = [];
       this.languages.json.jsonDefaults.setDiagnosticsOptions;
     }
     get languages() {
@@ -47,7 +49,21 @@
     }
     postMessage(msg) {
       msg.editorReference = this._editorReference_;
-      this._iframe_.contentWindow.postMessage(msg, document.location.href);
+      if (this._messageFlowActive_) {
+        this._iframe_.contentWindow.postMessage(msg, document.location.href);
+      }
+      else {
+        this._delayedMessages_.push(msg);
+      }
+    }
+    setMessageFlowActive(value) {
+      this._messageFlowActive = value;
+      if (value) {
+        for (let msg of this._delayedMessages_) {
+          this._iframe_.contentWindow.postMessage(msg, document.location.href);
+        }
+        this._delayedMessages_ = [];
+      }
     }
     get editor() {
       return {
@@ -103,11 +119,28 @@
     constructor(iframe, editorReference) {
       this._iframe_ = iframe;
       this._editorReference_ = editorReference;
+      this._messageFlowActive_ = false;
+      this._delayedMessages_ = [];
     }
 
     postMessage(msg) {
       msg.editorReference = this._editorReference_;
-      this._iframe_.contentWindow.postMessage(msg, document.location.href);
+      if (this._messageFlowActive_) {
+        this._iframe_.contentWindow.postMessage(msg, document.location.href);
+      }
+      else {
+        this._delayedMessages_.push(msg);
+      }
+    }
+
+    setMessageFlowActive(value) {
+      this._messageFlowActive = value;
+      if (value) {
+        for (let msg of this._delayedMessages_) {
+          this._iframe_.contentWindow.postMessage(msg, document.location.href);
+        }
+        this._delayedMessages_ = [];
+      }
     }
 
     updateOptions(opts) {
@@ -170,6 +203,10 @@
     }
     get proxy() {
       return this._proxy_;
+    }
+    activateMessageFlow() {
+      this.editor.setMessageFlowActive(true);
+      this.monaco.setMessageFlowActive(true);
     }
     resize(w, h) {
       this.node.style.height = h;

--- a/monaco-editor-iframe.js
+++ b/monaco-editor-iframe.js
@@ -57,7 +57,7 @@
       }
     }
     setMessageFlowActive(value) {
-      this._messageFlowActive = value;
+      this._messageFlowActive_ = value;
       if (value) {
         for (let msg of this._delayedMessages_) {
           this._iframe_.contentWindow.postMessage(msg, document.location.href);
@@ -134,7 +134,7 @@
     }
 
     setMessageFlowActive(value) {
-      this._messageFlowActive = value;
+      this._messageFlowActive_ = value;
       if (value) {
         for (let msg of this._delayedMessages_) {
           this._iframe_.contentWindow.postMessage(msg, document.location.href);

--- a/monaco-editor.html
+++ b/monaco-editor.html
@@ -590,6 +590,7 @@ class MonacoEditor extends Polymer.Element {
   }
 
   _initIFrame() {
+      var iframe = new PolymerVis.monaco.MonacoIFrame(this.shadowRoot);
     window.addEventListener('message', ({data}) => {
       if(data.editorReference !== this.editorReference) return;
       if (data.event === 'value-changed') {
@@ -602,10 +603,10 @@ class MonacoEditor extends Polymer.Element {
 
       if (data.event === 'editor-message-handler-ready') {
           this._valueChanged(this.value);
+          iframe.activateMessageFlow();
       };
     });
 
-    var iframe = new PolymerVis.monaco.MonacoIFrame(this.shadowRoot);
     iframe.resize(this.clientWidth, this.clientHeight);
     iframe.init(
       this.libPath,


### PR DESCRIPTION
Functions that are called "too early" were sent via message before the iframe has established its event listener. So now, we just delay all messages in editor- and monaco-proxy until we got the OK.