### PR TITLE
Clear hover providers

### DIFF
--- a/monaco-editor-iframe.js
+++ b/monaco-editor-iframe.js
@@ -42,6 +42,16 @@
             event: 'registerSignatureHelpProvider',
             args: [languageId, provider]
           });
+        },
+        registerHoverProvider: (languageId, provider) => {
+          if (provider.provideHover) {
+            provider.provideHover = provider.provideHover.toString();
+          }
+          this.postMessage({
+            path: ['monaco', 'languages'],
+            event: 'registerHoverProvider',
+            args: [languageId, provider]
+          });
         }
       };
     }
@@ -329,6 +339,11 @@
               if (event === 'registerSignatureHelpProvider') {
                 if (args[1].provideSignatureHelp) {
                   args[1].provideSignatureHelp = eval(args[1].provideSignatureHelp);
+                }
+              }
+              if (event === 'registerHoverProvider') {
+                if (args[1].provideHover) {
+                  args[1].provideHover = eval(args[1].provideHover);
                 }
               }
               try {


### PR DESCRIPTION
This is a helper function I used to clear hover providers, since we don't get the disposables that are usually returned from registerHoverProvider. Since it's not a direct interface to the original monaco library, I moved this to its own pull requests. 
This request depends on #15.